### PR TITLE
Add npm cleanup step to cache integration workflow

### DIFF
--- a/.github/workflows/cache-integration-tests.yml
+++ b/.github/workflows/cache-integration-tests.yml
@@ -52,8 +52,12 @@ jobs:
           redis-cli -p 7002 cluster info || exit 1
           redis-cli -p 7003 cluster info || exit 1
 
+      - name: Clean npm environment
+        run: |
+          rm -rf node_modules package-lock.json
+
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build packages
         run: |


### PR DESCRIPTION
## Summary
- add workflow step to remove stale node_modules and package-lock.json
- switch cache integration workflow to reinstall dependencies after cleanup

## Testing
- not run (CI workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de2a26a708326839bcb332b22abc7)