### PR TITLE
Fix JWT typing and clean up Redis test teardown

### DIFF
--- a/packages/api/src/cache/__tests__/cacheFactory/limiterCache.cache_integration.spec.ts
+++ b/packages/api/src/cache/__tests__/cacheFactory/limiterCache.cache_integration.spec.ts
@@ -24,6 +24,11 @@ describe('limiterCache', () => {
     jest.resetModules();
   });
 
+  afterAll(async () => {
+    const redisClients = await import('../../redisClients');
+    await redisClients.closeRedisClients();
+  });
+
   test('should throw error when prefix is not provided', async () => {
     const cacheFactory = await import('../../cacheFactory');
     expect(() => cacheFactory.limiterCache('')).toThrow('prefix is required');

--- a/packages/api/src/crypto/jwt.ts
+++ b/packages/api/src/crypto/jwt.ts
@@ -1,4 +1,4 @@
-import jwt from 'jsonwebtoken';
+import { sign, SignOptions } from 'jsonwebtoken';
 
 /**
  * Generate a short-lived JWT token
@@ -6,9 +6,16 @@ import jwt from 'jsonwebtoken';
  * @param {String} [expireIn='5m'] - The expiration time for the token (default is 5 minutes)
  * @returns {String} - The generated JWT token
  */
-export const generateShortLivedToken = (userId: string, expireIn: string = '5m'): string => {
-  return jwt.sign({ id: userId }, process.env.JWT_SECRET!, {
+export const generateShortLivedToken = (userId: string, expireIn = '5m'): string => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is required to generate tokens');
+  }
+
+  const options: SignOptions = {
     expiresIn: expireIn,
     algorithm: 'HS256',
-  });
+  };
+
+  return sign({ id: userId }, secret, options);
 };


### PR DESCRIPTION
## Summary
- update JWT token generation to use explicit jsonwebtoken signing options and secret validation
- add a reusable Redis client shutdown helper and invoke it in limiter cache integration tests to prevent leaked connections

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e3d6f149c8326b4ba91c80772008f)