### PR TITLE
Ensure Redis clients are closed after limiter cache tests

### DIFF
--- a/packages/api/src/cache/__tests__/cacheFactory/limiterCache.cache_integration.spec.ts
+++ b/packages/api/src/cache/__tests__/cacheFactory/limiterCache.cache_integration.spec.ts
@@ -21,6 +21,35 @@ describe('limiterCache', () => {
 
   afterEach(async () => {
     process.env = originalEnv;
+
+    if (testStore) {
+      const maybeClient =
+        (testStore as any).client || (testStore as any).redis || (testStore as any).clientRedis;
+
+      if (maybeClient) {
+        try {
+          if (typeof maybeClient.quit === 'function') {
+            await maybeClient.quit();
+          } else if (typeof maybeClient.disconnect === 'function') {
+            await maybeClient.disconnect();
+          }
+        } catch (err) {
+          // Swallow errors to avoid masking test failures while ensuring cleanup attempts
+        }
+      }
+
+      testStore = undefined;
+    }
+
+    try {
+      const redisClients = await import('../../redisClients');
+      if (typeof redisClients.closeRedisClients === 'function') {
+        await redisClients.closeRedisClients();
+      }
+    } catch (err) {
+      // Ignore cleanup errors to prevent interfering with test results
+    }
+
     jest.resetModules();
   });
 


### PR DESCRIPTION
## Summary
- add per-test cleanup for limiter cache integration tests to close RedisStore clients
- ensure shared redis clients are closed after each test to prevent leaked handles

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f07f3ab6883269d6fdd021754ba66)