### PR TITLE
fix: address CodeQL security findings and ReDoS patterns

### DIFF
--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -52,7 +52,7 @@ router.get('/oauth/openid/check', (req, res) => {
   res.status(200).json({ message: 'OpenID check successful' });
 });
 
-router.get('/oauth/openid', (req, res, next) => {
+router.get('/oauth/openid', middleware.loginLimiter, (req, res, next) => {
   return passport.authenticate('openidAdmin', {
     session: false,
     state: randomState(),
@@ -67,6 +67,7 @@ router.get(
     session: false,
   }),
   requireAdmin,
+  middleware.loginLimiter,
   setBalanceConfig,
   middleware.checkDomainAllowed,
   createOAuthHandler(`${getAdminPanelUrl()}/auth/openid/callback`),

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -1,4 +1,5 @@
 const fs = require('fs').promises;
+const path = require('path');
 const express = require('express');
 const { EnvVar } = require('@librechat/agents');
 const { logger } = require('@librechat/data-schemas');
@@ -33,6 +34,35 @@ const { getAssistant } = require('~/models/Assistant');
 const { getAgent } = require('~/models/Agent');
 const { getLogStores } = require('~/cache');
 const { Readable } = require('stream');
+
+const getUploadRootPath = (req) => {
+  const uploadRoot = req.config?.paths?.uploads;
+  return typeof uploadRoot === 'string' && uploadRoot.length > 0
+    ? path.resolve(uploadRoot)
+    : path.resolve(process.cwd(), 'uploads');
+};
+
+const isPathWithinRoot = (filePath, rootPath) => {
+  const resolvedPath = path.resolve(filePath);
+  if (resolvedPath === rootPath) {
+    return true;
+  }
+  return resolvedPath.startsWith(`${rootPath}${path.sep}`);
+};
+
+const safeUnlink = async (req, filePath) => {
+  if (!filePath) {
+    return;
+  }
+
+  const rootPath = getUploadRootPath(req);
+  if (!isPathWithinRoot(filePath, rootPath)) {
+    logger.warn(`[/files] Refusing to delete file outside upload root: ${filePath}`);
+    return;
+  }
+
+  await fs.unlink(path.resolve(filePath));
+};
 
 const router = express.Router();
 
@@ -443,7 +473,7 @@ router.post('/', async (req, res) => {
     }
 
     try {
-      await fs.unlink(req.file.path);
+      await safeUnlink(req, req.file?.path);
       cleanup = false;
     } catch (error) {
       logger.error('[/files] Error deleting file:', error);
@@ -452,7 +482,7 @@ router.post('/', async (req, res) => {
   } finally {
     if (cleanup) {
       try {
-        await fs.unlink(req.file.path);
+        await safeUnlink(req, req.file?.path);
       } catch (error) {
         logger.error('[/files] Error deleting file after file processing:', error);
       }

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -155,7 +155,10 @@ export async function fetchModels({
       options.headers['OpenAI-Organization'] = process.env.OPENAI_ORGANIZATION;
     }
 
-    const url = new URL(`${(baseURL ?? '').replace(/\/+$/, '')}${azure ? '' : '/models'}`);
+    const normalizedBaseURL = (baseURL ?? '').endsWith('/')
+      ? (baseURL ?? '').slice(0, -1)
+      : (baseURL ?? '');
+    const url = new URL(`${normalizedBaseURL}${azure ? '' : '/models'}`);
     if (user && userIdQuery) {
       url.searchParams.append('user', user);
     }

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -290,7 +290,11 @@ export function getOpenAILLMConfig({
         delete llmConfig[param as keyof t.OAIClientOptions];
       }
     });
-  } else if (modelOptions.model && /gpt-4o.*search/.test(modelOptions.model as string)) {
+  } else if (
+    typeof modelOptions.model === 'string' &&
+    modelOptions.model.startsWith('gpt-4o') &&
+    modelOptions.model.includes('search')
+  ) {
     /**
      * Note: OpenAI Web Search models do not support any known parameters besides `max_tokens`
      */

--- a/packages/api/src/oauth/csrf.ts
+++ b/packages/api/src/oauth/csrf.ts
@@ -8,6 +8,28 @@ export const OAUTH_SESSION_COOKIE = 'oauth_session';
 export const OAUTH_SESSION_MAX_AGE = 24 * 60 * 60 * 1000;
 export const OAUTH_SESSION_COOKIE_PATH = '/api';
 
+const OAUTH_SESSION_TOKEN_BYTES = 32;
+
+function getOAuthSessionSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET is required for OAuth session token generation');
+  }
+  return secret;
+}
+
+function toBase64Url(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
+
+function fromBase64Url(value: string): string | null {
+  try {
+    return Buffer.from(value, 'base64url').toString('utf8');
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Determines if secure cookies should be used.
  * Returns `true` in production unless the server is running on localhost (HTTP).
@@ -94,9 +116,26 @@ export function setOAuthSession(req: Request, res: Response, next: NextFunction)
   next();
 }
 
+/** Creates a signed OAuth session token bound to a user ID with expiration */
+export function generateOAuthSessionToken(
+  userId: string,
+  maxAge: number = OAUTH_SESSION_MAX_AGE,
+): string {
+  const issuedAt = Date.now();
+  const expiresAt = issuedAt + maxAge;
+  const nonce = crypto.randomBytes(OAUTH_SESSION_TOKEN_BYTES).toString('hex');
+  const payload = JSON.stringify({ uid: userId, iat: issuedAt, exp: expiresAt, nonce });
+  const encodedPayload = toBase64Url(payload);
+  const signature = crypto
+    .createHmac('sha256', getOAuthSessionSecret())
+    .update(encodedPayload)
+    .digest('base64url');
+  return `${encodedPayload}.${signature}`;
+}
+
 /** Sets a SameSite=Lax session cookie that binds the browser to the authenticated userId */
 export function setOAuthSessionCookie(res: Response, userId: string): void {
-  res.cookie(OAUTH_SESSION_COOKIE, generateOAuthCsrfToken(userId), {
+  res.cookie(OAUTH_SESSION_COOKIE, generateOAuthSessionToken(userId), {
     httpOnly: true,
     secure: shouldUseSecureCookie(),
     sameSite: 'lax',
@@ -105,15 +144,48 @@ export function setOAuthSessionCookie(res: Response, userId: string): void {
   });
 }
 
-/** Validates the session cookie against the expected userId using timing-safe comparison */
+/** Validates the signed session cookie against the expected userId */
 export function validateOAuthSession(req: Request, userId: string): boolean {
   const cookie = (req.cookies as Record<string, string> | undefined)?.[OAUTH_SESSION_COOKIE];
   if (!cookie) {
     return false;
   }
-  const expected = generateOAuthCsrfToken(userId);
-  if (cookie.length !== expected.length) {
+
+  const parts = cookie.split('.');
+  if (parts.length !== 2) {
     return false;
   }
-  return crypto.timingSafeEqual(Buffer.from(cookie), Buffer.from(expected));
+
+  const [encodedPayload, signature] = parts;
+  if (!encodedPayload || !signature) {
+    return false;
+  }
+
+  const expectedSignature = crypto
+    .createHmac('sha256', getOAuthSessionSecret())
+    .update(encodedPayload)
+    .digest('base64url');
+
+  if (signature.length !== expectedSignature.length) {
+    return false;
+  }
+
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+    return false;
+  }
+
+  const payload = fromBase64Url(encodedPayload);
+  if (!payload) {
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(payload) as { uid?: string; exp?: number };
+    if (parsed.uid !== userId || typeof parsed.exp !== 'number') {
+      return false;
+    }
+    return Date.now() <= parsed.exp;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
### Motivation
- Remediate multiple CodeQL/security alerts: ReDoS-prone regexes, insecure/clear-text session cookie usage, missing rate limiting on admin OAuth routes, and unsafe filesystem unlinking from user-controlled paths.
- Keep changes minimal in JS route wrappers under `/api` while applying TypeScript fixes in `packages/api` per workspace boundaries.

### Description
- Add rate limiting to admin OpenID endpoints by applying `middleware.loginLimiter` to `GET /oauth/openid` and the callback route in `api/server/routes/admin/auth.js` to prevent abuse of auth/database-touching routes.
- Replace polynomial/unsafe regex usage with constant-time string operations: normalize trailing slashes using string trimming in `packages/api/src/endpoints/models.ts` and replace `/gpt-4o.*search/` with `startsWith` + `includes` in `packages/api/src/endpoints/openai/llm.ts` to avoid ReDoS risks.
- Replace deterministic session cookie derived from `userId` with a signed, expiring token format by adding `generateOAuthSessionToken` and updating `setOAuthSessionCookie` / `validateOAuthSession` to verify HMAC signatures and expiration in `packages/api/src/oauth/csrf.ts`.
- Harden file cleanup by introducing `safeUnlink` which resolves and restricts deletions to the configured uploads root and using it in `api/server/routes/files/files.js` where `fs.unlink` was previously called on untrusted paths.

### Testing
- Ran linting: `npx eslint packages/api/src/endpoints/models.ts packages/api/src/endpoints/openai/llm.ts packages/api/src/oauth/csrf.ts api/server/routes/admin/auth.js api/server/routes/files/files.js` and fixed formatting issues; lint completed successfully after fixes.
- Ran package tests: `cd packages/api && npx jest src/oauth/csrf.ts --passWithNoTests` (no tests found, run succeeded with no failures).
- Ran route tests: `cd api && npx jest server/routes/files/files.test.js --runInBand`; this locally failed due to missing test wiring for `@librechat/data-schemas` in the test environment (dependency resolution), not because of the functional changes made.
- Manual static checks: verified updated code paths for signature validation (`generateOAuthSessionToken` / `validateOAuthSession`), safe unlink usage, and replacement of the two risky regexes.

Files changed (high level): `api/server/routes/admin/auth.js`, `api/server/routes/files/files.js`, `packages/api/src/endpoints/models.ts`, `packages/api/src/endpoints/openai/llm.ts`, and `packages/api/src/oauth/csrf.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df2cfb74883268045f4e31b7d9599)