### PR TITLE
fix: align root axios override with workspace dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
       "@anthropic-ai/sdk": "0.73.0",
       "fast-xml-parser": "5.3.6"
     },
-    "axios": "1.12.1",
+    "axios": "^1.13.5",
     "elliptic": "^6.6.1",
     "fast-xml-parser": "5.3.6",
     "form-data": "^4.0.4",


### PR DESCRIPTION
### Motivation
- Resolve an `npm ci` failure caused by a mismatch between the root `overrides.axios` value and workspace package expectations so CI and local installs use a consistent axios version.

### Description
- Update `overrides.axios` in the root `package.json` from `1.12.1` to `^1.13.5` to match the versions expected by workspace packages and the lockfile resolution.

### Testing
- Ran `npm ci --ignore-scripts` from the repository root and the install completed successfully (no `npm ci` lockfile mismatch error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e13b9badc8326be2dd888d13f7de7)