### PR TITLE
Fix ESLint formatting and add missing test assertion

### DIFF
--- a/api/server/services/Config/loadCustomConfig.spec.js
+++ b/api/server/services/Config/loadCustomConfig.spec.js
@@ -195,7 +195,8 @@ describe('loadCustomConfig', () => {
     };
     process.env.CONFIG_PATH = 'validConfig.yaml';
     loadYaml.mockReturnValueOnce(mockConfig);
-    await loadCustomConfig();
+    const result = await loadCustomConfig();
+    expect(result).toEqual(mockConfig);
   });
 
   it('should log the loaded custom config', async () => {

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -413,8 +413,8 @@ const nativeTools = new Set([Tools.execute_code, Tools.file_search, Tools.web_se
 const isBuiltInTool = (toolName) =>
   Boolean(
     manifestToolMap[toolName] ||
-      toolkits.some((t) => t.pluginKey === toolName) ||
-      nativeTools.has(toolName),
+    toolkits.some((t) => t.pluginKey === toolName) ||
+    nativeTools.has(toolName),
   );
 
 /**

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -152,8 +152,8 @@ async function reinitMCPServer({
       availableTools,
       success: Boolean(
         (connection && !oauthRequired) ||
-          (oauthRequired && oauthUrl) ||
-          (tools && tools.length > 0),
+        (oauthRequired && oauthUrl) ||
+        (tools && tools.length > 0),
       ),
       message: getResponseMessage(),
       oauthRequired,


### PR DESCRIPTION
### Motivation
- Resolve Prettier/ESLint formatting errors that caused the CI ESLint job to fail and eliminate a `jest/expect-expect` warning in a config test.

### Description
- Adjusted whitespace/alignment in `api/server/services/ToolService.js` to satisfy Prettier in the built-in tool detection boolean chain.
- Adjusted whitespace/alignment in `api/server/services/Tools/mcp.js` to satisfy Prettier in the MCP reinitialization success condition.
- Added an assertion to `api/server/services/Config/loadCustomConfig.spec.js` so the `cache: false` test verifies the returned config with `expect(result).toEqual(mockConfig)`.

### Testing
- Ran `npx eslint api/server/services/ToolService.js api/server/services/Tools/mcp.js api/server/services/Config/loadCustomConfig.spec.js` which reported no remaining formatting errors for the targeted files.
- Ran `cd api && npx jest server/services/Config/loadCustomConfig.spec.js` which failed in this environment due to module resolution for `@librechat/api` (test file change is correct but the CI-like environment lacks that dependency).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699edd8cd3b08326b474e19f5ddc0274)