### PR TITLE
Harden security-sensitive parsing and OAuth token handling

### DIFF
--- a/api/server/routes/balance.js
+++ b/api/server/routes/balance.js
@@ -1,8 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/Balance');
-const { requireJwtAuth } = require('../middleware/');
+const { requireJwtAuth, loginLimiter } = require('../middleware/');
 
-router.get('/', requireJwtAuth, controller);
+router.get('/', loginLimiter, requireJwtAuth, controller);
 
 module.exports = router;

--- a/api/server/routes/files/images.js
+++ b/api/server/routes/files/images.js
@@ -11,6 +11,21 @@ const {
 
 const router = express.Router();
 
+const sanitizePathSegment = (value = '') => value.replace(/[^a-zA-Z0-9_-]/g, '');
+
+const createSafeImagePath = (basePath, userId, filename) => {
+  const safeUserId = sanitizePathSegment(userId);
+  const safeFilename = path.basename(filename);
+  const userPath = path.resolve(basePath, safeUserId);
+  const filePath = path.resolve(userPath, safeFilename);
+
+  if (!filePath.startsWith(`${userPath}${path.sep}`) && filePath !== userPath) {
+    return null;
+  }
+
+  return filePath;
+};
+
 router.post('/', async (req, res) => {
   const metadata = req.body;
   const appConfig = req.config;
@@ -41,12 +56,15 @@ router.post('/', async (req, res) => {
     }
 
     try {
-      const filepath = path.join(
+      const filepath = createSafeImagePath(
         appConfig.paths.imageOutput,
-        req.user.id,
-        path.basename(req.file.filename),
+        req.user?.id,
+        req.file?.filename ?? '',
       );
-      await fs.unlink(filepath);
+
+      if (filepath) {
+        await fs.unlink(filepath);
+      }
     } catch (error) {
       logger.error('[/files/images] Error deleting file:', error);
     }

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -36,7 +36,7 @@ const {
   getMCPManager,
 } = require('~/config');
 const { getMCPSetupData, getServerConnectionStatus } = require('~/server/services/MCP');
-const { requireJwtAuth, canAccessMCPServerResource } = require('~/server/middleware');
+const { requireJwtAuth, canAccessMCPServerResource, loginLimiter } = require('~/server/middleware');
 const { findToken, updateToken, createToken, deleteTokens } = require('~/models');
 const { getUserPluginAuthValue } = require('~/server/services/PluginService');
 const { updateMCPServerTools } = require('~/server/services/Config/mcp');
@@ -48,6 +48,8 @@ const { getLogStores } = require('~/cache');
 const router = Router();
 
 const OAUTH_CSRF_COOKIE_PATH = '/api/mcp';
+
+router.use(loginLimiter);
 
 /**
  * Get all MCP tools available to the user

--- a/config/create-user.js
+++ b/config/create-user.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const crypto = require('crypto');
 const mongoose = require('mongoose');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
@@ -14,7 +15,9 @@ const connect = require('./connect');
   console.purple('--------------------------');
 
   if (process.argv.length < 5) {
-    console.orange('Usage: npm run create-user -- <email> <name> <username> [--email-verified=false]');
+    console.orange(
+      'Usage: npm run create-user -- <email> <name> <username> [--email-verified=false]',
+    );
     console.orange('Note: if you do not pass in the arguments, you will be prompted for them.');
     console.orange(
       'If you really need to pass in the password, you can do so as the 4th argument (not recommended for security).',
@@ -72,7 +75,7 @@ const connect = require('./connect');
   if (password === undefined) {
     password = await askQuestion('Password: (leave blank, to generate one)');
     if (!password) {
-      password = Math.random().toString(36).slice(-18);
+      password = crypto.randomBytes(18).toString('base64url');
       console.orange('Your password is: ' + password);
     }
   }
@@ -88,9 +91,9 @@ If \`n\`, and email service is configured, the user will be sent a verification 
 If \`n\`, and email service is not configured, you must have the \`ALLOW_UNVERIFIED_EMAIL_LOGIN\` .env variable set to true,
 or the user will need to attempt logging in to have a verification link sent to them.`);
 
-    const normalizedEmailVerifiedInput = emailVerifiedInput.trim().toLowerCase()
+    const normalizedEmailVerifiedInput = emailVerifiedInput.trim().toLowerCase();
 
-    emailVerified = true
+    emailVerified = true;
 
     if (normalizedEmailVerifiedInput === 'n') {
       emailVerified = false;

--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -151,7 +151,14 @@ export function getOpenAIConfig(
         return;
       }
 
-      const updatedUrl = configOptions.baseURL?.replace(/\/deployments(?:\/.*)?$/, '/v1');
+      const currentBaseUrl = configOptions.baseURL;
+      let updatedUrl = currentBaseUrl;
+      if (currentBaseUrl) {
+        const deploymentSegmentIndex = currentBaseUrl.indexOf('/deployments/');
+        if (deploymentSegmentIndex >= 0) {
+          updatedUrl = `${currentBaseUrl.slice(0, deploymentSegmentIndex)}/v1`;
+        }
+      }
 
       configOptions.baseURL = constructAzureURL({
         baseURL: updatedUrl || 'https://${INSTANCE_NAME}.openai.azure.com/openai/v1',

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -1,6 +1,15 @@
 import { Constants } from 'librechat-data-provider';
 
-export const mcpToolPattern = new RegExp(`^.+${Constants.mcp_delimiter}.+$`);
+/**
+ * Escapes special regex characters in a string so they are treated literally.
+ * @param str - The string to escape
+ * @returns The escaped string safe for use in a regex pattern
+ */
+export function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export const mcpToolPattern = new RegExp(escapeRegex(Constants.mcp_delimiter));
 /**
  * Normalizes a server name to match the pattern ^[a-zA-Z0-9_.-]+$
  * This is required for Azure OpenAI models with Tool Calling
@@ -44,15 +53,6 @@ export function sanitizeUrlForLogging(url: string | URL): string {
   } catch {
     return '[invalid URL]';
   }
-}
-
-/**
- * Escapes special regex characters in a string so they are treated literally.
- * @param str - The string to escape
- * @returns The escaped string safe for use in a regex pattern
- */
-export function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**

--- a/packages/api/src/oauth/csrf.ts
+++ b/packages/api/src/oauth/csrf.ts
@@ -9,6 +9,16 @@ export const OAUTH_SESSION_MAX_AGE = 24 * 60 * 60 * 1000;
 export const OAUTH_SESSION_COOKIE_PATH = '/api';
 
 const OAUTH_SESSION_TOKEN_BYTES = 32;
+const OAUTH_TOKEN_NONCE_BYTES = 12;
+const OAUTH_TOKEN_TAG_BYTES = 16;
+
+type OAuthEncryptedPayload = {
+  uid?: string;
+  fid?: string;
+  iat?: number;
+  exp: number;
+  nonce: string;
+};
 
 function getOAuthSessionSecret(): string {
   const secret = process.env.JWT_SECRET;
@@ -18,13 +28,55 @@ function getOAuthSessionSecret(): string {
   return secret;
 }
 
-function toBase64Url(value: string): string {
-  return Buffer.from(value, 'utf8').toString('base64url');
+function getOAuthEncryptionKey(): Buffer {
+  return crypto.createHash('sha256').update(getOAuthSessionSecret(), 'utf8').digest();
 }
 
-function fromBase64Url(value: string): string | null {
+function encryptOAuthPayload(payload: OAuthEncryptedPayload): string {
+  const iv = crypto.randomBytes(OAUTH_TOKEN_NONCE_BYTES);
+  const cipher = crypto.createCipheriv('aes-256-gcm', getOAuthEncryptionKey(), iv);
+  const encodedPayload = JSON.stringify(payload);
+  const encrypted = Buffer.concat([cipher.update(encodedPayload, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return `${iv.toString('base64url')}.${encrypted.toString('base64url')}.${authTag.toString('base64url')}`;
+}
+
+function decryptOAuthPayload(token: string): OAuthEncryptedPayload | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const [ivBase64Url, payloadBase64Url, authTagBase64Url] = parts;
+  if (!ivBase64Url || !payloadBase64Url || !authTagBase64Url) {
+    return null;
+  }
+
+  let iv: Buffer;
+  let encryptedPayload: Buffer;
+  let authTag: Buffer;
+
   try {
-    return Buffer.from(value, 'base64url').toString('utf8');
+    iv = Buffer.from(ivBase64Url, 'base64url');
+    encryptedPayload = Buffer.from(payloadBase64Url, 'base64url');
+    authTag = Buffer.from(authTagBase64Url, 'base64url');
+  } catch {
+    return null;
+  }
+
+  if (iv.length !== OAUTH_TOKEN_NONCE_BYTES || authTag.length !== OAUTH_TOKEN_TAG_BYTES) {
+    return null;
+  }
+
+  try {
+    const decipher = crypto.createDecipheriv('aes-256-gcm', getOAuthEncryptionKey(), iv);
+    decipher.setAuthTag(authTag);
+    const decryptedPayload = Buffer.concat([
+      decipher.update(encryptedPayload),
+      decipher.final(),
+    ]).toString('utf8');
+    return JSON.parse(decryptedPayload) as OAuthEncryptedPayload;
   } catch {
     return null;
   }
@@ -62,13 +114,13 @@ export function shouldUseSecureCookie(): boolean {
   return isProduction && !isLocalhost;
 }
 
-/** Generates an HMAC-based token for OAuth CSRF protection */
-export function generateOAuthCsrfToken(flowId: string, secret?: string): string {
-  const key = secret || process.env.JWT_SECRET;
-  if (!key) {
-    throw new Error('JWT_SECRET is required for OAuth CSRF token generation');
-  }
-  return crypto.createHmac('sha256', key).update(flowId).digest('hex').slice(0, 32);
+/** Generates an encrypted token for OAuth CSRF protection */
+export function generateOAuthCsrfToken(flowId: string): string {
+  return encryptOAuthPayload({
+    fid: flowId,
+    exp: Date.now() + OAUTH_CSRF_MAX_AGE,
+    nonce: crypto.randomBytes(OAUTH_TOKEN_NONCE_BYTES).toString('base64url'),
+  });
 }
 
 /** Sets a SameSite=Lax CSRF cookie bound to a specific OAuth flow */
@@ -83,8 +135,8 @@ export function setOAuthCsrfCookie(res: Response, flowId: string, cookiePath: st
 }
 
 /**
- * Validates the per-flow CSRF cookie against the expected HMAC.
- * Uses timing-safe comparison and always clears the cookie to prevent replay.
+ * Validates the per-flow CSRF cookie against the expected OAuth flow.
+ * Always clears the cookie to prevent replay.
  */
 export function validateOAuthCsrf(
   req: Request,
@@ -97,11 +149,13 @@ export function validateOAuthCsrf(
   if (!cookie) {
     return false;
   }
-  const expected = generateOAuthCsrfToken(flowId);
-  if (cookie.length !== expected.length) {
+
+  const payload = decryptOAuthPayload(cookie);
+  if (!payload || payload.fid !== flowId || typeof payload.exp !== 'number') {
     return false;
   }
-  return crypto.timingSafeEqual(Buffer.from(cookie), Buffer.from(expected));
+
+  return Date.now() <= payload.exp;
 }
 
 /**
@@ -116,21 +170,18 @@ export function setOAuthSession(req: Request, res: Response, next: NextFunction)
   next();
 }
 
-/** Creates a signed OAuth session token bound to a user ID with expiration */
+/** Creates an encrypted OAuth session token bound to a user ID with expiration */
 export function generateOAuthSessionToken(
   userId: string,
   maxAge: number = OAUTH_SESSION_MAX_AGE,
 ): string {
   const issuedAt = Date.now();
-  const expiresAt = issuedAt + maxAge;
-  const nonce = crypto.randomBytes(OAUTH_SESSION_TOKEN_BYTES).toString('hex');
-  const payload = JSON.stringify({ uid: userId, iat: issuedAt, exp: expiresAt, nonce });
-  const encodedPayload = toBase64Url(payload);
-  const signature = crypto
-    .createHmac('sha256', getOAuthSessionSecret())
-    .update(encodedPayload)
-    .digest('base64url');
-  return `${encodedPayload}.${signature}`;
+  return encryptOAuthPayload({
+    uid: userId,
+    iat: issuedAt,
+    exp: issuedAt + maxAge,
+    nonce: crypto.randomBytes(OAUTH_SESSION_TOKEN_BYTES).toString('base64url'),
+  });
 }
 
 /** Sets a SameSite=Lax session cookie that binds the browser to the authenticated userId */
@@ -144,48 +195,17 @@ export function setOAuthSessionCookie(res: Response, userId: string): void {
   });
 }
 
-/** Validates the signed session cookie against the expected userId */
+/** Validates the encrypted session cookie against the expected userId */
 export function validateOAuthSession(req: Request, userId: string): boolean {
   const cookie = (req.cookies as Record<string, string> | undefined)?.[OAUTH_SESSION_COOKIE];
   if (!cookie) {
     return false;
   }
 
-  const parts = cookie.split('.');
-  if (parts.length !== 2) {
+  const payload = decryptOAuthPayload(cookie);
+  if (!payload || payload.uid !== userId || typeof payload.exp !== 'number') {
     return false;
   }
 
-  const [encodedPayload, signature] = parts;
-  if (!encodedPayload || !signature) {
-    return false;
-  }
-
-  const expectedSignature = crypto
-    .createHmac('sha256', getOAuthSessionSecret())
-    .update(encodedPayload)
-    .digest('base64url');
-
-  if (signature.length !== expectedSignature.length) {
-    return false;
-  }
-
-  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
-    return false;
-  }
-
-  const payload = fromBase64Url(encodedPayload);
-  if (!payload) {
-    return false;
-  }
-
-  try {
-    const parsed = JSON.parse(payload) as { uid?: string; exp?: number };
-    if (parsed.uid !== userId || typeof parsed.exp !== 'number') {
-      return false;
-    }
-    return Date.now() <= parsed.exp;
-  } catch {
-    return false;
-  }
+  return Date.now() <= payload.exp;
 }

--- a/packages/api/src/utils/graph.ts
+++ b/packages/api/src/utils/graph.ts
@@ -11,10 +11,9 @@ import {
  * Pre-computed regex for matching the Graph token placeholder.
  * Escapes curly braces in the placeholder string for safe regex use.
  */
-const GRAPH_TOKEN_REGEX = new RegExp(
-  GRAPH_TOKEN_PLACEHOLDER.replace(/[{}]/g, '\\$&'),
-  'g',
-);
+const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const GRAPH_TOKEN_REGEX = new RegExp(escapeRegex(GRAPH_TOKEN_PLACEHOLDER), 'g');
 
 /**
  * Response from a Graph API token exchange.
@@ -143,7 +142,9 @@ export async function resolveGraphTokenPlaceholder(
       return value.replace(GRAPH_TOKEN_REGEX, graphTokenResponse.access_token);
     }
 
-    logger.warn('[resolveGraphTokenPlaceholder] Graph token exchange did not return an access token');
+    logger.warn(
+      '[resolveGraphTokenPlaceholder] Graph token exchange did not return an access token',
+    );
     return value;
   } catch (error) {
     logger.error('[resolveGraphTokenPlaceholder] Failed to exchange token for Graph API:', error);
@@ -185,14 +186,13 @@ export async function resolveGraphTokensInRecord(
  * @param graphOptions - Options for Graph token resolution
  * @returns The options with Graph token placeholders resolved
  */
-export async function preProcessGraphTokens<T extends {
-  headers?: Record<string, string>;
-  env?: Record<string, string>;
-  url?: string;
-}>(
-  options: T,
-  graphOptions: GraphTokenOptions,
-): Promise<T> {
+export async function preProcessGraphTokens<
+  T extends {
+    headers?: Record<string, string>;
+    env?: Record<string, string>;
+    url?: string;
+  },
+>(options: T, graphOptions: GraphTokenOptions): Promise<T> {
   if (!mcpOptionsContainGraphTokenPlaceholder(options)) {
     return options;
   }

--- a/packages/data-provider/src/utils.ts
+++ b/packages/data-provider/src/utils.ts
@@ -1,4 +1,20 @@
-export const envVarRegex = /^\${(.+)}$/;
+export const envVarRegex = /^\$\{([^{}]+)\}$/;
+
+const ENV_VAR_PREFIX = '${';
+const ENV_VAR_SUFFIX = '}';
+
+function isSimpleEnvVariableReference(value: string): boolean {
+  return value.startsWith(ENV_VAR_PREFIX) && value.endsWith(ENV_VAR_SUFFIX);
+}
+
+function parseEnvVariableName(value: string): string | null {
+  if (!isSimpleEnvVariableReference(value)) {
+    return null;
+  }
+
+  const varName = value.slice(ENV_VAR_PREFIX.length, -ENV_VAR_SUFFIX.length);
+  return varName.length > 0 && !varName.includes(ENV_VAR_SUFFIX) ? varName : null;
+}
 
 /** Extracts the environment variable name from a template literal string */
 export function extractVariableName(value: string): string | null {
@@ -6,8 +22,7 @@ export function extractVariableName(value: string): string | null {
     return null;
   }
 
-  const match = value.trim().match(envVarRegex);
-  return match ? match[1] : null;
+  return parseEnvVariableName(value.trim());
 }
 
 /** Extracts the value of an environment variable from a string. */
@@ -16,38 +31,35 @@ export function extractEnvVariable(value: string) {
     return value;
   }
 
-  // Trim the input
   const trimmed = value.trim();
 
-  // Special case: if it's just a single environment variable
-  const singleMatch = trimmed.match(envVarRegex);
-  if (singleMatch) {
-    const varName = singleMatch[1];
-    return process.env[varName] || trimmed;
+  const singleVariableName = parseEnvVariableName(trimmed);
+  if (singleVariableName) {
+    return process.env[singleVariableName] || trimmed;
   }
 
-  // For multiple variables, process them using a regex loop
-  const regex = /\${([^}]+)}/g;
-  let result = trimmed;
+  let result = '';
+  let index = 0;
 
-  // First collect all matches and their positions
-  const matches = [];
-  let match;
-  while ((match = regex.exec(trimmed)) !== null) {
-    matches.push({
-      fullMatch: match[0],
-      varName: match[1],
-      index: match.index,
-    });
-  }
+  while (index < trimmed.length) {
+    const startIndex = trimmed.indexOf(ENV_VAR_PREFIX, index);
+    if (startIndex < 0) {
+      result += trimmed.slice(index);
+      break;
+    }
 
-  // Process matches in reverse order to avoid position shifts
-  for (let i = matches.length - 1; i >= 0; i--) {
-    const { fullMatch, varName, index } = matches[i];
-    const envValue = process.env[varName] || fullMatch;
+    result += trimmed.slice(index, startIndex);
 
-    // Replace at exact position
-    result = result.substring(0, index) + envValue + result.substring(index + fullMatch.length);
+    const endIndex = trimmed.indexOf(ENV_VAR_SUFFIX, startIndex + ENV_VAR_PREFIX.length);
+    if (endIndex < 0) {
+      result += trimmed.slice(startIndex);
+      break;
+    }
+
+    const variableName = trimmed.slice(startIndex + ENV_VAR_PREFIX.length, endIndex);
+    const fullMatch = trimmed.slice(startIndex, endIndex + 1);
+    result += process.env[variableName] || fullMatch;
+    index = endIndex + 1;
   }
 
   return result;


### PR DESCRIPTION
### Motivation
- Prevent regex-based DoS and unsafe parsing from untrusted inputs by replacing backtracking-prone patterns with deterministic scanners and proper escaping. 
- Protect OAuth CSRF/session material from cleartext exposure and weak hashing by moving to authenticated encryption with explicit expiry checks. 
- Eliminate weak randomness and path traversal risks in utility scripts and file cleanup code. 

### Description
- Replace regex-heavy environment-variable extraction/interpolation with a single-pass scanner and stricter matching in `packages/data-provider/src/utils.ts` to avoid catastrophic backtracking. 
- Escape all regex metacharacters when composing the Graph placeholder matcher in `packages/api/src/utils/graph.ts` to ensure safe, literal matching. 
- Convert CSRF/session tokens to AES-256-GCM encrypted payloads with nonce/auth tag handling and explicit expiry validation in `packages/api/src/oauth/csrf.ts`. 
- Simplify and harden MCP delimiter matching by escaping the delimiter in `packages/api/src/mcp/utils.ts`, and replace a brittle Azure deployment-path regex with index-based slicing in `packages/api/src/endpoints/openai/config.ts`. 
- Use cryptographically secure `crypto.randomBytes` for password generation in `config/create-user.js`. 
- Constrain image cleanup path resolution to a sanitized user subpath in `api/server/routes/files/images.js` to reduce path traversal/file deletion risk. 
- Apply `loginLimiter` on legacy sensitive routes in `api/server/routes/balance.js` and `api/server/routes/mcp.js` to add rate limiting at additional entry points. 

### Testing
- Ran formatting with `npx prettier --write` on all touched files and it completed successfully. 
- Ran linting with `npx eslint` on all touched files and it reported no blocking issues. 
- Attempted `npm run build:data-provider` but the build failed in this environment due to a missing optional Rollup native package (`@rollup/rollup-linux-x64-gnu`), which is an environment provisioning issue and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee01f20ec8326a9c363564efe3454)