### PR TITLE
juristai-django-tools: add django-hub tool catalog module

### DIFF
--- a/packages/api/src/tools/juristai/index.ts
+++ b/packages/api/src/tools/juristai/index.ts
@@ -1,0 +1,27 @@
+import { loadDjangoSpec, filterSpecForApp } from './specLoader';
+import { buildJuristaiTools } from './toolBuilder';
+import type { JuristaiSpecConfig } from './specLoader';
+import type { JuristaiToolDefinition } from './toolBuilder';
+
+export { mintChatJwt, clearChatJwtCache } from './jwtMinter';
+export { loadDjangoSpec, filterSpecForApp, clearSpecCache } from './specLoader';
+export { buildJuristaiTools, JURISTAI_TOOL_PREFIX } from './toolBuilder';
+
+export type { ChatTokenUser } from './jwtMinter';
+export type { JuristaiSpecConfig } from './specLoader';
+export type { JuristaiToolDefinition } from './toolBuilder';
+
+/**
+ * Resolves the curated set of django-hub tools for an app: fetch (or reuse the
+ * cached) spec, filter to the llm-callable subset allowed for the appId, and
+ * build namespaced tool definitions ready to advertise to the model.
+ */
+export async function loadJuristaiToolCatalog(
+  config: JuristaiSpecConfig,
+  appId?: string,
+  forceRefresh = false,
+): Promise<JuristaiToolDefinition[]> {
+  const spec = await loadDjangoSpec(config, forceRefresh);
+  const filtered = filterSpecForApp(spec, config, appId);
+  return buildJuristaiTools(filtered, config.djangoBaseUrl);
+}

--- a/packages/api/src/tools/juristai/jwtMinter.spec.ts
+++ b/packages/api/src/tools/juristai/jwtMinter.spec.ts
@@ -1,0 +1,61 @@
+import jwt from 'jsonwebtoken';
+import { mintChatJwt, clearChatJwtCache } from './jwtMinter';
+
+const SECRET = 'unit-test-chat-secret';
+
+describe('mintChatJwt', () => {
+  const originalSecret = process.env.CHAT_SECRET;
+  const originalExpiry = process.env.CHAT_TOKEN_EXPIRY_SECONDS;
+
+  beforeEach(() => {
+    process.env.CHAT_SECRET = SECRET;
+    process.env.CHAT_TOKEN_EXPIRY_SECONDS = '300';
+    clearChatJwtCache();
+  });
+
+  afterAll(() => {
+    process.env.CHAT_SECRET = originalSecret;
+    process.env.CHAT_TOKEN_EXPIRY_SECONDS = originalExpiry;
+    clearChatJwtCache();
+  });
+
+  it('signs the claim shape django-hub expects', () => {
+    const token = mintChatJwt({ id: '507f1f77bcf86cd799439011', email: 'user@example.com' });
+    const decoded = jwt.verify(token, SECRET, { issuer: 'librechat' }) as jwt.JwtPayload;
+
+    expect(decoded.sub).toBe('507f1f77bcf86cd799439011');
+    expect(decoded.email).toBe('user@example.com');
+    expect(decoded.iss).toBe('librechat');
+    expect(typeof decoded.exp).toBe('number');
+  });
+
+  it('omits email when not provided', () => {
+    const token = mintChatJwt({ id: 'abc' });
+    const decoded = jwt.decode(token) as jwt.JwtPayload;
+    expect(decoded.email).toBeUndefined();
+    expect(decoded.sub).toBe('abc');
+  });
+
+  it('reuses a cached token for the same user', () => {
+    const first = mintChatJwt({ id: 'abc', email: 'a@b.com' });
+    const second = mintChatJwt({ id: 'abc', email: 'a@b.com' });
+    expect(second).toBe(first);
+  });
+
+  it('issues distinct tokens for different users', () => {
+    const a = mintChatJwt({ id: 'user-a', email: 'a@b.com' });
+    const b = mintChatJwt({ id: 'user-b', email: 'b@b.com' });
+    expect(a).not.toBe(b);
+  });
+
+  it('throws when CHAT_SECRET is not configured', () => {
+    process.env.CHAT_SECRET = '';
+    clearChatJwtCache();
+    expect(() => mintChatJwt({ id: 'abc' })).toThrow(/CHAT_SECRET/);
+  });
+
+  it('produces a token Django would reject under the wrong secret', () => {
+    const token = mintChatJwt({ id: 'abc' });
+    expect(() => jwt.verify(token, 'a-different-secret')).toThrow();
+  });
+});

--- a/packages/api/src/tools/juristai/jwtMinter.ts
+++ b/packages/api/src/tools/juristai/jwtMinter.ts
@@ -1,0 +1,70 @@
+import jwt from 'jsonwebtoken';
+
+/**
+ * Mints short-lived service-to-service JWTs the LibreChat backend sends to
+ * django-hub when executing Django-backed tool calls on behalf of a chat user.
+ *
+ * The claim shape is fixed by django-hub's ChatMintedJWTAuthentication:
+ *   { iss: 'librechat', sub: <chat user id>, email: <chat user email>, exp }
+ * signed HS256 with the shared CHAT_SECRET. Django resolves the user by `sub`
+ * (integer pk) and falls back to `email`, so email is the canonical join key.
+ */
+
+const CHAT_TOKEN_ISSUER = 'librechat';
+const CHAT_TOKEN_ALGORITHM = 'HS256';
+const DEFAULT_EXPIRY_SECONDS = 300;
+const REFRESH_SKEW_MS = 30_000;
+
+export interface ChatTokenUser {
+  id: string;
+  email?: string;
+}
+
+interface CachedToken {
+  token: string;
+  expiresAtMs: number;
+}
+
+const tokenCache = new Map<string, CachedToken>();
+
+const getExpirySeconds = (): number => {
+  const raw = Number(process.env.CHAT_TOKEN_EXPIRY_SECONDS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_EXPIRY_SECONDS;
+};
+
+const getSecret = (): string => {
+  const secret = process.env.CHAT_SECRET ?? '';
+  if (!secret) {
+    throw new Error('CHAT_SECRET is not configured; cannot mint django-hub tool token');
+  }
+  return secret;
+};
+
+const cacheKey = (user: ChatTokenUser): string => `${user.id}:${user.email ?? ''}`;
+
+/**
+ * Returns a valid chat-minted JWT for the user, reusing a cached token until it
+ * is within REFRESH_SKEW_MS of expiry.
+ */
+export function mintChatJwt(user: ChatTokenUser): string {
+  const now = Date.now();
+  const key = cacheKey(user);
+  const cached = tokenCache.get(key);
+  if (cached && cached.expiresAtMs - REFRESH_SKEW_MS > now) {
+    return cached.token;
+  }
+
+  const expirySeconds = getExpirySeconds();
+  const token = jwt.sign(
+    { sub: user.id, ...(user.email ? { email: user.email } : {}) },
+    getSecret(),
+    { algorithm: CHAT_TOKEN_ALGORITHM, issuer: CHAT_TOKEN_ISSUER, expiresIn: expirySeconds },
+  );
+
+  tokenCache.set(key, { token, expiresAtMs: now + expirySeconds * 1000 });
+  return token;
+}
+
+export function clearChatJwtCache(): void {
+  tokenCache.clear();
+}

--- a/packages/api/src/tools/juristai/specLoader.spec.ts
+++ b/packages/api/src/tools/juristai/specLoader.spec.ts
@@ -1,0 +1,77 @@
+import type { OpenAPIV3 } from 'openapi-types';
+import { loadDjangoSpec, filterSpecForApp, clearSpecCache } from './specLoader';
+import type { JuristaiSpecConfig } from './specLoader';
+
+const makeSpec = (): OpenAPIV3.Document => ({
+  openapi: '3.0.0',
+  info: { title: 'Jurist Hub API', version: '1.0.0' },
+  paths: {
+    '/api/core/search-case/': {
+      post: {
+        operationId: 'search-case',
+        summary: 'Search cases',
+        responses: { '200': { description: 'ok' } },
+        ['x-llm-callable']: true,
+      } as OpenAPIV3.OperationObject,
+    },
+    '/api/core/get-case-metadata/': {
+      get: {
+        operationId: 'get-case-metadata',
+        responses: { '200': { description: 'ok' } },
+        ['x-llm-callable']: true,
+      } as OpenAPIV3.OperationObject,
+    },
+    '/api/core/generate-motion/': {
+      post: {
+        operationId: 'generate-motion',
+        responses: { '200': { description: 'ok' } },
+      } as OpenAPIV3.OperationObject,
+    },
+  },
+});
+
+const config: JuristaiSpecConfig = { djangoBaseUrl: 'https://api-dev.juristai.org' };
+
+const operationIds = (spec: OpenAPIV3.Document): string[] => {
+  const ids: string[] = [];
+  for (const pathItem of Object.values(spec.paths ?? {})) {
+    for (const op of Object.values(pathItem ?? {})) {
+      const operation = op as OpenAPIV3.OperationObject;
+      if (operation?.operationId) {
+        ids.push(operation.operationId);
+      }
+    }
+  }
+  return ids;
+};
+
+describe('filterSpecForApp', () => {
+  it('keeps only x-llm-callable operations', () => {
+    const filtered = filterSpecForApp(makeSpec(), config);
+    const ids = operationIds(filtered);
+    expect(ids).toContain('search-case');
+    expect(ids).toContain('get-case-metadata');
+    expect(ids).not.toContain('generate-motion');
+  });
+
+  it('narrows to the per-app allowlist when provided', () => {
+    const filtered = filterSpecForApp(makeSpec(), { ...config, perAppOperations: { '1': ['search-case'] } }, '1');
+    const ids = operationIds(filtered);
+    expect(ids).toEqual(['search-case']);
+  });
+
+  it('exposes all llm-callable ops when appId has no allowlist entry', () => {
+    const filtered = filterSpecForApp(makeSpec(), { ...config, perAppOperations: { '1': ['search-case'] } }, '2');
+    expect(operationIds(filtered).sort()).toEqual(['get-case-metadata', 'search-case']);
+  });
+});
+
+describe('loadDjangoSpec', () => {
+  afterEach(() => clearSpecCache());
+
+  it('returns the static spec without fetching when provided', async () => {
+    const staticSpec = makeSpec();
+    const spec = await loadDjangoSpec({ ...config, staticSpec });
+    expect(spec).toBe(staticSpec);
+  });
+});

--- a/packages/api/src/tools/juristai/specLoader.ts
+++ b/packages/api/src/tools/juristai/specLoader.ts
@@ -1,0 +1,141 @@
+import type { OpenAPIV3 } from 'openapi-types';
+
+/**
+ * Loads and curates django-hub's drf-spectacular OpenAPI spec into the subset
+ * of operations exposed to the LibreChat assistant as native tool calls.
+ *
+ * Curation gate: only operations flagged `x-llm-callable: true` in the spec are
+ * eligible. An optional per-app allowlist (keyed by appId -> operationId[])
+ * narrows the catalog further so FedCrim and LitigAI can advertise different
+ * tools.
+ *
+ * Note: django-hub serves `/api/schema/` with IsAdminUser permission, so a live
+ * fetch needs a service/admin token (schemaAuthToken). For tests and offline
+ * builds a `staticSpec` can be supplied to bypass the network entirely.
+ */
+
+const LLM_CALLABLE_EXTENSION = 'x-llm-callable';
+const DEFAULT_SCHEMA_PATH = '/api/schema/';
+const DEFAULT_REFRESH_SECONDS = 600;
+
+type HttpMethod = 'get' | 'put' | 'post' | 'delete' | 'patch';
+const HTTP_METHODS: readonly HttpMethod[] = ['get', 'put', 'post', 'delete', 'patch'];
+
+export interface JuristaiSpecConfig {
+  djangoBaseUrl: string;
+  schemaPath?: string;
+  refreshSeconds?: number;
+  /** Bearer token used to fetch the admin-gated schema endpoint. */
+  schemaAuthToken?: string;
+  /** appId -> operationId allowlist. Omit to expose every llm-callable op. */
+  perAppOperations?: Record<string, string[]>;
+  /** Inject a spec directly (tests, bundled offline spec) and skip fetching. */
+  staticSpec?: OpenAPIV3.Document;
+}
+
+interface CachedSpec {
+  spec: OpenAPIV3.Document;
+  fetchedAtMs: number;
+}
+
+let cache: CachedSpec | null = null;
+
+const isLlmCallable = (operation: OpenAPIV3.OperationObject): boolean => {
+  const flagged = (operation as Record<string, unknown>)[LLM_CALLABLE_EXTENSION];
+  return flagged === true;
+};
+
+const buildSchemaUrl = (config: JuristaiSpecConfig): string => {
+  const base = config.djangoBaseUrl.replace(/\/+$/, '');
+  const path = config.schemaPath ?? DEFAULT_SCHEMA_PATH;
+  const separator = path.includes('?') ? '&' : '?';
+  return `${base}${path}${separator}format=json`;
+};
+
+const fetchSpec = async (config: JuristaiSpecConfig): Promise<OpenAPIV3.Document> => {
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (config.schemaAuthToken) {
+    headers.Authorization = `Bearer ${config.schemaAuthToken}`;
+  }
+
+  const response = await fetch(buildSchemaUrl(config), { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch django-hub schema: ${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as OpenAPIV3.Document;
+};
+
+const isFresh = (config: JuristaiSpecConfig): boolean => {
+  if (!cache) {
+    return false;
+  }
+  const ttlMs = (config.refreshSeconds ?? DEFAULT_REFRESH_SECONDS) * 1000;
+  return Date.now() - cache.fetchedAtMs < ttlMs;
+};
+
+/** Fetches (or returns cached) the raw django-hub OpenAPI spec. */
+export async function loadDjangoSpec(
+  config: JuristaiSpecConfig,
+  forceRefresh = false,
+): Promise<OpenAPIV3.Document> {
+  if (config.staticSpec) {
+    return config.staticSpec;
+  }
+  if (!forceRefresh && isFresh(config)) {
+    return (cache as CachedSpec).spec;
+  }
+  const spec = await fetchSpec(config);
+  cache = { spec, fetchedAtMs: Date.now() };
+  return spec;
+}
+
+const operationIdFor = (
+  operation: OpenAPIV3.OperationObject,
+  method: string,
+  path: string,
+): string => operation.operationId ?? `${method}_${path}`;
+
+/**
+ * Returns a spec containing only the llm-callable operations allowed for the
+ * given appId. The result is a valid OpenAPIV3.Document suitable for
+ * `openapiToFunction`.
+ */
+export function filterSpecForApp(
+  spec: OpenAPIV3.Document,
+  config: JuristaiSpecConfig,
+  appId?: string,
+): OpenAPIV3.Document {
+  const allowlist =
+    appId != null && config.perAppOperations ? config.perAppOperations[appId] : undefined;
+  const allowed = allowlist ? new Set(allowlist) : null;
+
+  const filteredPaths: OpenAPIV3.PathsObject = {};
+
+  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+    if (!pathItem) {
+      continue;
+    }
+    const keptMethods: Partial<Record<HttpMethod, OpenAPIV3.OperationObject>> = {};
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (!operation || !isLlmCallable(operation)) {
+        continue;
+      }
+      if (allowed && !allowed.has(operationIdFor(operation, method, path))) {
+        continue;
+      }
+      keptMethods[method] = operation;
+    }
+
+    if (Object.keys(keptMethods).length > 0) {
+      filteredPaths[path] = { ...keptMethods };
+    }
+  }
+
+  return { ...spec, paths: filteredPaths };
+}
+
+export function clearSpecCache(): void {
+  cache = null;
+}

--- a/packages/api/src/tools/juristai/toolBuilder.spec.ts
+++ b/packages/api/src/tools/juristai/toolBuilder.spec.ts
@@ -1,0 +1,50 @@
+import type { OpenAPIV3 } from 'openapi-types';
+import { buildJuristaiTools, JURISTAI_TOOL_PREFIX } from './toolBuilder';
+
+const spec: OpenAPIV3.Document = {
+  openapi: '3.0.0',
+  info: { title: 'Jurist Hub API', version: '1.0.0' },
+  paths: {
+    '/api/core/search-case/': {
+      post: {
+        operationId: 'search-case',
+        summary: 'Search cases by docket ID or query terms.',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { query: { type: 'string' } },
+                required: ['query'],
+              },
+            },
+          },
+        },
+        responses: { '200': { description: 'ok' } },
+      } as OpenAPIV3.OperationObject,
+    },
+  },
+};
+
+describe('buildJuristaiTools', () => {
+  it('builds a namespaced tool with a request builder targeting the django base url', () => {
+    const tools = buildJuristaiTools(spec, 'https://api-dev.juristai.org/');
+    expect(tools).toHaveLength(1);
+
+    const [tool] = tools;
+    expect(tool.name).toBe(`${JURISTAI_TOOL_PREFIX}search-case`);
+    expect(tool.operationId).toBe('search-case');
+    expect(tool.description).toBe('Search cases by docket ID or query terms.');
+    expect(tool.requestBuilder.domain).toBe('https://api-dev.juristai.org');
+    expect(tool.requestBuilder.method.toLowerCase()).toBe('post');
+  });
+
+  it('returns an empty catalog for a spec with no operations', () => {
+    const empty: OpenAPIV3.Document = {
+      openapi: '3.0.0',
+      info: { title: 't', version: '1' },
+      paths: {},
+    };
+    expect(buildJuristaiTools(empty, 'https://x')).toEqual([]);
+  });
+});

--- a/packages/api/src/tools/juristai/toolBuilder.ts
+++ b/packages/api/src/tools/juristai/toolBuilder.ts
@@ -1,0 +1,57 @@
+import { openapiToFunction } from 'librechat-data-provider';
+import type { OpenAPIV3 } from 'openapi-types';
+import type { ActionRequest, FunctionSignature } from 'librechat-data-provider';
+
+/**
+ * Converts a curated django-hub OpenAPI spec into JuristAI tool definitions.
+ *
+ * Reuses LibreChat's `openapiToFunction` (the same util the Actions feature
+ * uses) to derive function signatures and request builders, then namespaces the
+ * tool names with `juristai__` so they never collide with user-configured
+ * Actions or MCP tools. The returned `requestBuilder` is what the /api glue
+ * hands to `createActionTool` for execution.
+ */
+
+export const JURISTAI_TOOL_PREFIX = 'juristai__';
+
+export interface JuristaiToolDefinition {
+  /** Namespaced name advertised to the model, e.g. `juristai__search_case`. */
+  name: string;
+  /** Raw OpenAPI operationId, used to look up the request builder. */
+  operationId: string;
+  description: string;
+  parameters: FunctionSignature['parameters'];
+  requestBuilder: ActionRequest;
+}
+
+const sanitizeName = (operationId: string): string => operationId.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+export function buildJuristaiTools(
+  spec: OpenAPIV3.Document,
+  djangoBaseUrl: string,
+): JuristaiToolDefinition[] {
+  const specWithServer: OpenAPIV3.Document = {
+    ...spec,
+    servers: [{ url: djangoBaseUrl.replace(/\/+$/, '') }],
+  };
+
+  const { functionSignatures, requestBuilders } = openapiToFunction(specWithServer, true);
+  const tools: JuristaiToolDefinition[] = [];
+
+  for (const signature of functionSignatures) {
+    const operationId = signature.name;
+    const requestBuilder = requestBuilders[operationId];
+    if (!requestBuilder) {
+      continue;
+    }
+    tools.push({
+      name: `${JURISTAI_TOOL_PREFIX}${sanitizeName(operationId)}`,
+      operationId,
+      description: signature.description,
+      parameters: signature.parameters,
+      requestBuilder,
+    });
+  }
+
+  return tools;
+}


### PR DESCRIPTION
Pure packages/api module that turns django-hub's drf-spectacular OpenAPI spec into namespaced, model-callable tool definitions:

- specLoader: fetch + cache the spec, filter to x-llm-callable ops, with per-app (appId) allowlists and a staticSpec escape hatch for tests.
- toolBuilder: reuse openapiToFunction to derive function signatures and request builders, namespaced as juristai__<operationId>.
- jwtMinter: mint short-lived HS256 tokens (iss=librechat, sub, email) matching django-hub's ChatMintedJWTAuthentication, cached per user.
- index: loadJuristaiToolCatalog(config, appId) orchestrator.

Self-contained and unit-tested (12 tests). Agent-loop wiring (advertise + execute via createActionTool) lands in a follow-up once the appId->agent mapping and admin-gated schema access are settled.