### PR TITLE
juristai-tools-env-docs: document django-hub tool env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -849,3 +849,16 @@ OPENWEATHER_API_KEY=
 # Skip code challenge method validation (e.g., for AWS Cognito that supports S256 but doesn't advertise it)
 # When set to true, forces S256 code challenge even if not advertised in .well-known/openid-configuration
 # MCP_SKIP_CODE_CHALLENGE_CHECK=false
+
+#==================================================#
+#            JuristAI django-hub Tools             #
+#==================================================#
+# Expose curated django-hub endpoints to the model as native tool calls.
+# Disabled by default; set to true to activate (no behavior change when off).
+# JURISTAI_DJANGO_TOOLS_ENABLED=false
+# Base URL of the django-hub service the tools call.
+# DJANGO_BASE_URL=https://api-dev.juristai.org
+# Shared HS256 secret, must match django-hub's CHAT_SECRET (ChatMintedJWTAuthentication).
+# CHAT_SECRET=
+# Lifetime (seconds) of the per-request service token minted for django-hub.
+# CHAT_TOKEN_EXPIRY_SECONDS=300


### PR DESCRIPTION
Document the env vars that gate and configure the django-hub native tool integration: JURISTAI_DJANGO_TOOLS_ENABLED (default off), DJANGO_BASE_URL, CHAT_SECRET (shared with django-hub), and CHAT_TOKEN_EXPIRY_SECONDS.