### PR TITLE
Pin compatible MCP SDK

### DIFF
--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -8,7 +8,8 @@ FROM python:3.12.7-slim-bookworm
 WORKDIR /app
 
 COPY mcp_server/requirements.txt ./mcp_server/requirements.txt
-RUN pip install --no-cache-dir -r mcp_server/requirements.txt
+RUN pip install --no-cache-dir -r mcp_server/requirements.txt \
+    && python -c "from mcp.server.fastmcp import FastMCP"
 
 COPY mcp_server ./mcp_server
 

--- a/mcp_server/requirements.txt
+++ b/mcp_server/requirements.txt
@@ -1,4 +1,4 @@
-mcp[cli]>=1.9.0
+mcp[cli]>=1.9.0,<2
 httpx>=0.28.1
 uvicorn[standard]>=0.30.6
 starlette>=0.41.0


### PR DESCRIPTION
## What changed
- Constrained `mcp[cli]` to the compatible 1.x SDK line.
- Added a Docker build-time `FastMCP` import smoke.

## Root cause
`mcp[cli]>=1.9.0` resolved to MCP 2.0.0 during run 30589926398. MCP 2 removed `mcp.server.fastmcp`, so the essential sidecar exited 1 and ECS repeatedly terminated the LibreChat task.

## Validation
- Production rolled back to healthy task definition 152 (1/1 running; target healthy).
- Python 3.12 resolves MCP 1.29.0.
- `FastMCP` and the vendored server app import successfully.
- `pip check` passes.